### PR TITLE
modify docqa

### DIFF
--- a/Transfer_Learning/document-qa/docqa.ipynb
+++ b/Transfer_Learning/document-qa/docqa.ipynb
@@ -14,14 +14,13 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "\n",
     "## Setup\n",
     "### Dependencies\n",
-    "We require python >= 3.5, tensorflow 1.2, and a handful of other supporting libraries. \n",
+    "We require python >= 3.5, tensorflow 1.10, and a handful of other supporting libraries. \n",
     "Tensorflow should be installed separately following the docs. To install the other dependencies use the commands below from a terminal in the linux DLVM first.\n",
     "\n",
     "```\n",

--- a/Transfer_Learning/document-qa/docqa.ipynb
+++ b/Transfer_Learning/document-qa/docqa.ipynb
@@ -14,6 +14,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -25,13 +26,13 @@
     "\n",
     "```\n",
     "\n",
-    "conda create --name <myenv>\n",
+    "conda create --name <myenv> Python=3.6\n",
     "source activate <myenv>\n",
     "cd /home/<user>/notebooks\n",
     "git clone https://github.com/antriv/Transfer_Learning_Text.git\n",
     "cd Transfer_Learning_Text/Transfer_Learning/document-qa/\n",
     "pip install -r requirements.txt\n",
-    "pip install tensorflow-gpu==1.2\n",
+    "pip install tensorflow-gpu\n",
     "python -m nltk.downloader punkt stopwords\n",
     "```\n",
     "\n",
@@ -40,10 +41,10 @@
     "```\n",
     "source activate <myenv>\n",
     "pip install ipykernel\n",
-    "sudo \"/home/<user>/.conda/envs/<myenv>/bin/python\" -m ipykernel install --name <docqa> --display-name \"<docqa>\"\n",
+    "sudo \"/home/<user>/.conda/envs/<myenv>/bin/python\" -m ipykernel install --name <myenv> --display-name \"<myenv>\"\n",
     "```\n",
     "\n",
-    "To run this notebook, choose the kernel `\"<docqa>\"`"
+    "To run this notebook, choose the kernel `\"<myenv>\"`"
    ]
   },
   {
@@ -198,7 +199,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/Transfer_Learning/document-qa/docqa/nn/recurrent_layers.py
+++ b/Transfer_Learning/document-qa/docqa/nn/recurrent_layers.py
@@ -5,7 +5,7 @@ from docqa.nn.layers import get_keras_activation, get_keras_initialization, Sequ
     MergeLayer, Encoder
 from tensorflow.contrib.cudnn_rnn.python.ops import cudnn_rnn_ops
 #from tensorflow.contrib.cudnn_rnn.python.ops.cudnn_rnn_ops import CudnnCompatibleGRUCell
-from tensorflow.contrib.keras.python.keras.initializers import TruncatedNormal
+from tensorflow.keras.initializers import TruncatedNormal
 from tensorflow.contrib.rnn import LSTMStateTuple, LSTMBlockFusedCell, GRUBlockCell
 from tensorflow.python.ops.rnn import dynamic_rnn, bidirectional_dynamic_rnn
 


### PR DESCRIPTION
There are two files modified: docqa.ipynb and  docqa/nn/recurrent_layers.py
Details:
conda create --name <myenv> Python=3.6  (if not specify this, many other stuff will be installed, cause issue)
pip install tensorflow-gpu    (I removed the part "==1.2" as I am currently use most recent version 1.10). 

In a NC6 DLVM, I first created a new conda env with Python 3.6. In this env, I then pip installed tensorflow-gpu==1.2 successfully. When I check if the tensorflow works or not by "import tensorflow", it shows error msg.  It is because DLVM has CUDA version 9.0, which is incompatible with tensorflow 1.2. 

I would suggest to include both tensorflow version and corresponding CUDA version. If DLVM keeps upgrading, the user is likely to encounter issue again.

===========================================
in file docqa/nn/recurrent_layers.py, 

ModuleNotFoundError: No module named 'tensorflow.contrib.keras.python'
from tensorflow.contrib.keras.python.keras.initializers import TruncatedNormal

I changed it to:
from tensorflow.keras.initializers import TruncatedNormal
